### PR TITLE
Fixing warning message about UIViewAnimationOptions 

### DIFF
--- a/MPNotificationView/MPNotificationView.m
+++ b/MPNotificationView/MPNotificationView.m
@@ -418,7 +418,7 @@ static CGFloat const __imagePadding = 8.0f;
     
     [UIView animateWithDuration:0.5
                           delay:0.0
-                        options:UIViewAnimationCurveEaseInOut
+                        options:UIViewAnimationOptionCurveEaseInOut
                      animations:^{
                          viewToRotateIn.layer.transform = CATransform3DIdentity;
                          viewToRotateOut.layer.transform = viewOutEndTransform;


### PR DESCRIPTION
Warning message solved :
MPNotificationView/MPNotificationView.m:421:33: Implicit conversion from enumeration type 'enum UIViewAnimationCurve' to different enumeration type 'UIViewAnimationOptions' (aka 'enum UIViewAnimationOptions')
