### PR TITLE
Fix rotation issue

### DIFF
--- a/MPNotificationViewTest/MPNotificationViewTest-Info.plist
+++ b/MPNotificationViewTest/MPNotificationViewTest-Info.plist
@@ -34,5 +34,12 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
The approach here is using `[[UIApplication sharedApplication] statusBarOrientation]` to get the interface orientation from status bar rather than from `[UIDevice currentDevice].orientation`.

Also, when user rotate the device while notification window is hidden, we need to wait for the status bar animation to be finished to get the right orientation. And that is what [line 79-83](https://github.com/zetachang/MPNotificationView/commit/9b60bd16017f8ccd7bd62fda4366f67a5ebbac41#L0R79) do.

This should fix Moped/MPNotificationView#14 and Moped/MPNotificationView#12 :smile: 
