### PR TITLE
Allow to register notification types to load custom Nibs/Classes

### DIFF
--- a/MPNotificationView/MPNotificationView.h
+++ b/MPNotificationView/MPNotificationView.h
@@ -53,8 +53,11 @@ typedef void (^MPNotificationSimpleAction)(id);
                                  detail:(NSString*)detail
                                   image:(UIImage*)image
                                duration:(NSTimeInterval)duration
-                                nibName:(NSString *)nibName
+                                   type:(NSString *)type
                           andTouchBlock:(MPNotificationSimpleAction)block;
+
++ (void)registerNibNameOrClass:(id)nibNameOrClass
+        forNotificationsOfType:(NSString *)type;
 
 @end
 

--- a/MPNotificationViewTest.xcodeproj/project.pbxproj
+++ b/MPNotificationViewTest.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		870D5D3816971F1500AB84FB /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 870D5D3716971F1500AB84FB /* LICENSE */; };
 		870D5D3A1697238000AB84FB /* mopedDog.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = 870D5D391697238000AB84FB /* mopedDog.jpeg */; };
 		A912ED42169DA20B0016A254 /* MainViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = A912ED41169DA20B0016A254 /* MainViewController.xib */; };
+		E58B5ACE1717D39C008BB0E0 /* MyNotificationView.m in Sources */ = {isa = PBXBuildFile; fileRef = E58B5ACD1717D39C008BB0E0 /* MyNotificationView.m */; };
 		E5B5558317095A960039E63F /* CustomNotificationView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E5B5558217095A960039E63F /* CustomNotificationView.xib */; };
 /* End PBXBuildFile section */
 
@@ -50,6 +51,8 @@
 		870D5D3716971F1500AB84FB /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		870D5D391697238000AB84FB /* mopedDog.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = mopedDog.jpeg; sourceTree = "<group>"; };
 		A912ED41169DA20B0016A254 /* MainViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = MainViewController.xib; sourceTree = "<group>"; };
+		E58B5ACC1717D39C008BB0E0 /* MyNotificationView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MyNotificationView.h; sourceTree = "<group>"; };
+		E58B5ACD1717D39C008BB0E0 /* MyNotificationView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MyNotificationView.m; sourceTree = "<group>"; };
 		E5B5558217095A960039E63F /* CustomNotificationView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomNotificationView.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -108,6 +111,8 @@
 				870D5D141696DA5A00AB84FB /* MPViewController.h */,
 				870D5D151696DA5A00AB84FB /* MPViewController.m */,
 				E5B5558217095A960039E63F /* CustomNotificationView.xib */,
+				E58B5ACC1717D39C008BB0E0 /* MyNotificationView.h */,
+				E58B5ACD1717D39C008BB0E0 /* MyNotificationView.m */,
 				870D5D001696DA5A00AB84FB /* Supporting Files */,
 			);
 			path = MPNotificationViewTest;
@@ -221,6 +226,7 @@
 				870D5D161696DA5A00AB84FB /* MPViewController.m in Sources */,
 				870D5D231696DA9E00AB84FB /* MPNotificationView.m in Sources */,
 				870D5D281696DC9400AB84FB /* OBGradientView.m in Sources */,
+				E58B5ACE1717D39C008BB0E0 /* MyNotificationView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MPNotificationViewTest/MPViewController.h
+++ b/MPNotificationViewTest/MPViewController.h
@@ -15,5 +15,6 @@
 -(IBAction) enqueueNotification2:(id)sender;
 -(IBAction) enqueueNotification3:(id)sender;
 -(IBAction) enqueueNotification4:(id)sender;
+-(IBAction) enqueueNotification5:(id)sender;
 
 @end

--- a/MPNotificationViewTest/MPViewController.m
+++ b/MPNotificationViewTest/MPViewController.m
@@ -7,12 +7,21 @@
 //
 
 #import "MPViewController.h"
+#import "MyNotificationView.h"
 
 @interface MPViewController ()
 
 @end
 
 @implementation MPViewController
+
++ (void)initialize
+{
+    [MPNotificationView registerNibNameOrClass:@"CustomNotificationView"
+                        forNotificationsOfType:@"Custom"];
+    [MPNotificationView registerNibNameOrClass:[MyNotificationView class]
+                        forNotificationsOfType:@"Blinking"];
+}
 
 - (void)dealloc
 {
@@ -64,13 +73,25 @@
 -(IBAction) enqueueNotification4:(id)sender
 {
     [MPNotificationView notifyWithText:@"Custom notification"
-                                detail:@"loaded from a Nib file"
+                                detail:@"loaded from a registered Nib file"
                                  image:[UIImage imageNamed:@"mopedDog.jpeg"]
                               duration:2.0
-                               nibName:@"CustomNotificationView"
+                                  type:@"Custom"
                          andTouchBlock:^(MPNotificationView *notificationView) {
                              NSLog( @"Received touch for notification with text: %@", notificationView.textLabel.text );
     }];
+}
+
+- (IBAction)enqueueNotification5:(id)sender
+{
+    [MPNotificationView notifyWithText:@"Custom notification"
+                                detail:@"instantiated from a registered Class"
+                                 image:[UIImage imageNamed:@"mopedDog.jpeg"]
+                              duration:2.0
+                                  type:@"Blinking"
+                         andTouchBlock:^(MPNotificationView *notificationView) {
+                             NSLog( @"Received touch for notification with text: %@", notificationView.textLabel.text );
+                         }];
 }
 
 - (void)didTapOnNotificationView:(MPNotificationView *)notificationView

--- a/MPNotificationViewTest/MainViewController.xib
+++ b/MPNotificationViewTest/MainViewController.xib
@@ -56,9 +56,9 @@
 					</object>
 					<object class="IBUIButton" id="570061368">
 						<reference key="NSNextResponder" ref="966032202"/>
-						<int key="NSvFlags">1294</int>
+						<int key="NSvFlags">1290</int>
 						<object class="NSPSMatrix" key="NSFrameMatrix"/>
-						<string key="NSFrame">{{20, 307}, {280, 44}}</string>
+						<string key="NSFrame">{{20, 248}, {280, 44}}</string>
 						<reference key="NSSuperview" ref="966032202"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1030798379"/>
@@ -92,9 +92,9 @@
 					</object>
 					<object class="IBUIButton" id="1030798379">
 						<reference key="NSNextResponder" ref="966032202"/>
-						<int key="NSvFlags">1294</int>
+						<int key="NSvFlags">1290</int>
 						<object class="NSPSMatrix" key="NSFrameMatrix"/>
-						<string key="NSFrame">{{20, 367}, {280, 44}}</string>
+						<string key="NSFrame">{{20, 308}, {280, 44}}</string>
 						<reference key="NSSuperview" ref="966032202"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="582721326"/>
@@ -115,9 +115,9 @@
 					</object>
 					<object class="IBUIButton" id="582721326">
 						<reference key="NSNextResponder" ref="966032202"/>
-						<int key="NSvFlags">1294</int>
+						<int key="NSvFlags">1290</int>
 						<object class="NSPSMatrix" key="NSFrameMatrix"/>
-						<string key="NSFrame">{{20, 426}, {280, 44}}</string>
+						<string key="NSFrame">{{20, 367}, {280, 44}}</string>
 						<reference key="NSSuperview" ref="966032202"/>
 						<reference key="NSWindow"/>
 						<bool key="IBUIOpaque">NO</bool>
@@ -137,7 +137,29 @@
 					</object>
 					<object class="IBUIButton" id="651269962">
 						<reference key="NSNextResponder" ref="966032202"/>
-						<int key="NSvFlags">1294</int>
+						<int key="NSvFlags">1290</int>
+						<object class="NSPSMatrix" key="NSFrameMatrix"/>
+						<string key="NSFrame">{{20, 426}, {280, 44}}</string>
+						<reference key="NSSuperview" ref="966032202"/>
+						<reference key="NSWindow"/>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<int key="IBUIButtonType">1</int>
+						<string key="IBUINormalTitle">Notification 4 (Registered Nib)</string>
+						<reference key="IBUIHighlightedTitleColor" ref="707667199"/>
+						<object class="NSColor" key="IBUINormalTitleColor">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MC4xOTYwNzg0MzQ2IDAuMzA5ODAzOTMyOSAwLjUyMTU2ODY1NgA</bytes>
+						</object>
+						<reference key="IBUINormalTitleShadowColor" ref="396199973"/>
+						<reference key="IBUIFontDescription" ref="832410450"/>
+						<reference key="IBUIFont" ref="702146649"/>
+					</object>
+					<object class="IBUIButton" id="192998962">
+						<reference key="NSNextResponder" ref="966032202"/>
+						<int key="NSvFlags">1290</int>
 						<object class="NSPSMatrix" key="NSFrameMatrix"/>
 						<string key="NSFrame">{{20, 485}, {280, 44}}</string>
 						<reference key="NSSuperview" ref="966032202"/>
@@ -147,7 +169,7 @@
 						<int key="IBUIContentHorizontalAlignment">0</int>
 						<int key="IBUIContentVerticalAlignment">0</int>
 						<int key="IBUIButtonType">1</int>
-						<string key="IBUINormalTitle">Notification 4 (Nib)</string>
+						<string key="IBUINormalTitle">Notification 5 (Registered Class)</string>
 						<reference key="IBUIHighlightedTitleColor" ref="707667199"/>
 						<object class="NSColor" key="IBUINormalTitleColor">
 							<int key="NSColorSpace">1</int>
@@ -4606,6 +4628,15 @@ AAgAAAAIAAIACAACAAAAAgAAAAEAAQABAAE</bytes>
 					</object>
 					<int key="connectionID">31</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">enqueueNotification5:</string>
+						<reference key="source" ref="192998962"/>
+						<reference key="destination" ref="841351856"/>
+						<int key="IBEventType">7</int>
+					</object>
+					<int key="connectionID">34</int>
+				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<array key="orderedObjects">
@@ -4631,10 +4662,11 @@ AAgAAAAIAAIACAACAAAAAgAAAAEAAQABAAE</bytes>
 						<reference key="object" ref="966032202"/>
 						<array class="NSMutableArray" key="children">
 							<reference ref="628380634"/>
-							<reference ref="651269962"/>
+							<reference ref="192998962"/>
 							<reference ref="570061368"/>
 							<reference ref="1030798379"/>
 							<reference ref="582721326"/>
+							<reference ref="651269962"/>
 						</array>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -4671,6 +4703,11 @@ AAgAAAAIAAIACAACAAAAAgAAAAEAAQABAAE</bytes>
 						<reference key="object" ref="651269962"/>
 						<reference key="parent" ref="966032202"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">32</int>
+						<reference key="object" ref="192998962"/>
+						<reference key="parent" ref="966032202"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -4684,6 +4721,9 @@ AAgAAAAIAAIACAACAAAAAgAAAAEAAQABAAE</bytes>
 				<string key="3.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<reference key="3.IBUserGuides" ref="0"/>
 				<boolean value="NO" key="3.showNotes"/>
+				<string key="32.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<reference key="32.IBUserGuides" ref="0"/>
+				<boolean value="NO" key="32.showNotes"/>
 				<string key="4.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<reference key="4.IBUserGuides" ref="0"/>
 				<boolean value="NO" key="4.showNotes"/>
@@ -4703,7 +4743,7 @@ AAgAAAAIAAIACAACAAAAAgAAAAEAAQABAAE</bytes>
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">31</int>
+			<int key="maxID">34</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -4715,6 +4755,7 @@ AAgAAAAIAAIACAACAAAAAgAAAAEAAQABAAE</bytes>
 						<string key="enqueueNotification2:">id</string>
 						<string key="enqueueNotification3:">id</string>
 						<string key="enqueueNotification4:">id</string>
+						<string key="enqueueNotification5:">id</string>
 					</dictionary>
 					<dictionary class="NSMutableDictionary" key="actionInfosByName">
 						<object class="IBActionInfo" key="enqueueNotification1:">
@@ -4731,6 +4772,10 @@ AAgAAAAIAAIACAACAAAAAgAAAAEAAQABAAE</bytes>
 						</object>
 						<object class="IBActionInfo" key="enqueueNotification4:">
 							<string key="name">enqueueNotification4:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="enqueueNotification5:">
+							<string key="name">enqueueNotification5:</string>
 							<string key="candidateClassName">id</string>
 						</object>
 					</dictionary>

--- a/MPNotificationViewTest/MyNotificationView.h
+++ b/MPNotificationViewTest/MyNotificationView.h
@@ -1,0 +1,14 @@
+//
+//  MyNotificationView.h
+//  MPNotificationViewTest
+//
+//  Created by 利辺羅 on 2013/04/12.
+//  Copyright (c) 2013年 Moped Inc. All rights reserved.
+//
+
+#import "MPNotificationView.h"
+
+@interface MyNotificationView : MPNotificationView
+
+@end
+

--- a/MPNotificationViewTest/MyNotificationView.m
+++ b/MPNotificationViewTest/MyNotificationView.m
@@ -1,0 +1,32 @@
+//
+//  MyNotificationView.m
+//  MPNotificationViewTest
+//
+//  Created by 利辺羅 on 2013/04/12.
+//  Copyright (c) 2013年 Moped Inc. All rights reserved.
+//
+
+#import "MyNotificationView.h"
+
+@implementation MyNotificationView
+
+- (id) initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self)
+    {
+        [UIView animateWithDuration:0.3
+                              delay:0.2
+                            options:UIViewAnimationOptionRepeat | UIViewAnimationOptionAutoreverse
+                         animations:^{
+                             self.textLabel.alpha = 0.5;
+                             self.detailTextLabel.alpha = 0.5;
+                         }
+                         completion:NULL];
+    }
+    
+    return self;
+}
+
+@end
+


### PR DESCRIPTION
Tweaked pull request #20 to allow to register NibNames for custom notification types.
Also added support to register MPNotificationView subclasses for people who don't like Nibs as much as I do ;)
